### PR TITLE
missing storage_key in demo added

### DIFF
--- a/website/more_documentation/storage_documentation.py
+++ b/website/more_documentation/storage_documentation.py
@@ -83,5 +83,6 @@ def more() -> None:
         # def index():
         #     ui.textarea('This note is kept between visits') \
         #         .classes('w-full').bind_value(app.storage.user, 'note')
+        # ui.run(storage_secret='private key to secure the browser session cookie')
         # END OF DEMO
         ui.textarea('This note is kept between visits').classes('w-full').bind_value(app.storage.user, 'note')


### PR DESCRIPTION
In the demo  [demo missing storage_key in demo added ](https://nicegui.io/documentation/storage#storing_ui_state) the secret_key is missing.